### PR TITLE
Add resolve property

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,22 @@ rollup({
 });
 ```
 
+An optional `resolve` array with file extensions can be provided.
+If present local aliases beginning with `./` will be resolved to existing files:
+
+```javascript
+import { rollup } from 'rollup';
+import alias from 'rollup-plugin-alias';
+
+rollup({
+  entry: './src/index.js',
+  plugins: [alias({
+    resolve: ['.jsx', '.js']
+    foo: './bar',  // Will check for ./bar.jsx and ./bar.js
+  })],
+});
+```
+If not given local aliases will be resolved with a `.js` extension.
+
 ## License
 MIT, see `LICENSE` for more information

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ export default function alias(options = {}) {
 
       const updatedId = importee.replace(toReplace, entry);
 
-      if (updatedId.indexOf('./') === 0) {
+      if (startsWith('./', updatedId)) {
         const directory = path.dirname(importer);
 
         // Resolve file names

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import path from 'path';
 // Helper functions
 const noop = () => null;
 // const identity = a => a;
+const startsWith = (needle, haystack) => ! haystack.indexOf(needle);
 
 export default function alias(options = {}) {
   const aliasKeys = Object.keys(options);
@@ -16,16 +17,16 @@ export default function alias(options = {}) {
 
   return {
     resolveId(importee, importer) {
-      // TODO: We shouldn't have a case of double aliases. But may need to handle that better
-      const filteredAlias = aliasKeys.filter(value => importee.indexOf(value) === 0)[0];
+      // First match is supposed to be the correct one
+      const toReplace = aliasKeys.find(key => startsWith(key, importee));
 
-      if (!filteredAlias) {
+      if (!toReplace) {
         return null;
       }
 
-      const entry = options[filteredAlias];
+      const entry = options[toReplace];
 
-      const updatedId = importee.replace(filteredAlias, entry);
+      const updatedId = importee.replace(toReplace, entry);
 
       if (updatedId.indexOf('./') === 0) {
         const basename = path.basename(importer);

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import fs from 'fs';
 
 // Helper functions
 const noop = () => null;
-// const identity = a => a;
 const startsWith = (needle, haystack) => ! haystack.indexOf(needle);
 const exists = uri => {
   try {

--- a/src/index.js
+++ b/src/index.js
@@ -29,8 +29,9 @@ export default function alias(options = {}) {
       const updatedId = importee.replace(toReplace, entry);
 
       if (updatedId.indexOf('./') === 0) {
-        const basename = path.basename(importer);
-        const directory = importer.split(basename)[0];
+        // const basename = path.basename(importer);
+        // const directory = importer.split(basename)[0];
+        const directory = path.dirname(importer);
 
         // TODO: Is there a way not to have the extension being defined explicitly?
         return path.resolve(directory, updatedId) + '.js';

--- a/src/index.js
+++ b/src/index.js
@@ -29,8 +29,6 @@ export default function alias(options = {}) {
       const updatedId = importee.replace(toReplace, entry);
 
       if (updatedId.indexOf('./') === 0) {
-        // const basename = path.basename(importer);
-        // const directory = importer.split(basename)[0];
         const directory = path.dirname(importer);
 
         // TODO: Is there a way not to have the extension being defined explicitly?

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,21 @@
 import path from 'path';
 
+// Helper functions
+const noop = () => null;
+// const identity = a => a;
+
 export default function alias(options = {}) {
+  const aliasKeys = Object.keys(options);
+
+  // No aliases?
+  if (!aliasKeys.length) {
+    return {
+      resolveId: noop,
+    };
+  }
+
   return {
     resolveId(importee, importer) {
-      if (Object.keys(options).length === 0) {
-        return null;
-      }
-
-      const aliasKeys = Object.keys(options);
       // TODO: We shouldn't have a case of double aliases. But may need to handle that better
       const filteredAlias = aliasKeys.filter(value => importee.indexOf(value) === 0)[0];
 

--- a/test/index.js
+++ b/test/index.js
@@ -59,6 +59,26 @@ test(t => {
   t.is(resolved, path.resolve(__dirname, './files/folder/hipster.jsx'));
 });
 
+test(t => {
+  const result = alias({
+    resolve: 'i/am/a/file',
+  });
+
+  const resolved = result.resolveId('resolve', '/src/import.js');
+
+  t.is(resolved, 'i/am/a/file');
+});
+
+test(t => {
+  const result = alias({
+    resolve: './i/am/a/local/file',
+  });
+
+  const resolved = result.resolveId('resolve', path.resolve(__dirname, './files/index.js'));
+
+  t.is(resolved, path.resolve(__dirname, './files/i/am/a/local/file.js'));
+});
+
 // Tests in Rollup
 test(t =>
   rollup({

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,51 @@ import test from 'ava';
 import { rollup } from 'rollup';
 import alias from '../dist/rollup-plugin-alias';
 
+test(t => {
+  t.is(typeof alias, 'function');
+});
+
+test(t => {
+  const result = alias();
+  t.is(typeof result, 'object');
+  t.is(typeof result.resolveId, 'function');
+});
+
+test(t => {
+  const result = alias({});
+  t.is(typeof result, 'object');
+  t.is(typeof result.resolveId, 'function');
+});
+
+// Simple aliasing
+test(t => {
+  const result = alias({
+    foo: 'bar',
+    pony: 'paradise',
+  });
+
+  const resolved = result.resolveId('foo', '/src/importer.js');
+  const resolved2 = result.resolveId('pony', '/src/importer.js');
+
+  t.is(resolved, 'bar');
+  t.is(resolved2, 'paradise');
+});
+
+// Local aliasing
+test(t => {
+  const result = alias({
+    foo: './bar',
+    pony: './par/a/di/se',
+  });
+
+  const resolved = result.resolveId('foo', '/src/importer.js');
+  const resolved2 = result.resolveId('pony', '/src/highly/nested/importer.js');
+
+  t.is(resolved, '/src/bar.js');
+  t.is(resolved2, '/src/highly/nested/par/a/di/se.js');
+});
+
+// Tests in Rollup
 test(t =>
   rollup({
     entry: './files/index.js',

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-
+import path from 'path';
 import { rollup } from 'rollup';
 import alias from '../dist/rollup-plugin-alias';
 
@@ -45,6 +45,18 @@ test(t => {
 
   t.is(resolved, '/src/bar.js');
   t.is(resolved2, '/src/highly/nested/par/a/di/se.js');
+});
+
+// Test for the resolve property
+test(t => {
+  const result = alias({
+    ember: './folder/hipster',
+    resolve: ['.js', '.jsx'],
+  });
+
+  const resolved = result.resolveId('ember', path.resolve(__dirname, './files/index.js'));
+
+  t.is(resolved, path.resolve(__dirname, './files/folder/hipster.jsx'));
 });
 
 // Tests in Rollup


### PR DESCRIPTION
This pull request adds the ability to provide a `resolve` array with file extensions used to resolve local aliases.

Also included:
- `Array.prototype.find()` is used to find aliases. Thus, the first match is supposed to be the correct one.
- If no aliases are given a dummy function is returned so that no more more checks during runtime are done
- Tests
