### PR TITLE
support absolute alias + fix extension appending

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ import fs from 'fs';
 // Helper functions
 const noop = () => null;
 const startsWith = (needle, haystack) => ! haystack.indexOf(needle);
+const endsWith = (needle, haystack) => haystack.slice(-needle.length) === needle;
+const isFilePath = id => /^\.?\//.test(id);
 const exists = uri => {
   try {
     return fs.statSync(uri).isFile();
@@ -38,7 +40,7 @@ export default function alias(options = {}) {
 
       const updatedId = importee.replace(toReplace, entry);
 
-      if (startsWith('./', updatedId)) {
+      if (isFilePath(updatedId)) {
         const directory = path.dirname(importer);
 
         // Resolve file names
@@ -52,6 +54,10 @@ export default function alias(options = {}) {
 
         // To keep the previous behaviour we simply return the file path
         // with extension
+        if (endsWith('.js', filePath)) {
+          return filePath;
+        }
+
         return filePath + '.js';
       }
 

--- a/test/index.js
+++ b/test/index.js
@@ -41,10 +41,32 @@ test(t => {
   });
 
   const resolved = result.resolveId('foo', '/src/importer.js');
-  const resolved2 = result.resolveId('pony', '/src/highly/nested/importer.js');
+  const resolved2 = result.resolveId('foo/baz', '/src/importer.js');
+  const resolved3 = result.resolveId('foo/baz.js', '/src/importer.js');
+  const resolved4 = result.resolveId('pony', '/src/highly/nested/importer.js');
 
   t.is(resolved, '/src/bar.js');
-  t.is(resolved2, '/src/highly/nested/par/a/di/se.js');
+  t.is(resolved2, '/src/bar/baz.js');
+  t.is(resolved3, '/src/bar/baz.js');
+  t.is(resolved4, '/src/highly/nested/par/a/di/se.js');
+});
+
+// Absolute local aliasing
+test(t => {
+  const result = alias({
+    foo: '/bar',
+    pony: '/par/a/di/se.js',
+  });
+
+  const resolved = result.resolveId('foo', '/src/importer.js');
+  const resolved2 = result.resolveId('foo/baz', '/src/importer.js');
+  const resolved3 = result.resolveId('foo/baz.js', '/src/importer.js');
+  const resolved4 = result.resolveId('pony', '/src/highly/nested/importer.js');
+
+  t.is(resolved, '/bar.js');
+  t.is(resolved2, '/bar/baz.js');
+  t.is(resolved3, '/bar/baz.js');
+  t.is(resolved4, '/par/a/di/se.js');
 });
 
 // Test for the resolve property


### PR DESCRIPTION
Currently aliasing to absolute paths is broken. Also, when the import path already includes the `.js` extension, it is still incorrectly appended.

This commit fixes both.
