### PR TITLE
Don't confuse modules with similar names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,17 +3,19 @@ import fs from 'fs';
 
 // Helper functions
 const noop = () => null;
-const isFilePath = id => /^\.?\//.test(id);
-const startsWith = (needle, haystack) => {
-  if (needle === haystack) {
+const matches = (key, importee) => {
+  if (importee.length < key.length) {
+    return false;
+  }
+  if (importee === key) {
     return true;
   }
-  if (isFilePath(haystack)) {
-    return haystack.replace('./', '').indexOf(needle) === 0;
-  }
-  return haystack.split('/')[0] === needle;
+  const importeeStartsWithKey = (importee.indexOf(key) === 0);
+  const importeeHasSlashAfterKey = (importee.substring(key.length)[0] === '/');
+  return importeeStartsWithKey && importeeHasSlashAfterKey;
 };
 const endsWith = (needle, haystack) => haystack.slice(-needle.length) === needle;
+const isFilePath = id => /^\.?\//.test(id);
 const exists = uri => {
   try {
     return fs.statSync(uri).isFile();
@@ -38,7 +40,7 @@ export default function alias(options = {}) {
   return {
     resolveId(importee, importer) {
       // First match is supposed to be the correct one
-      const toReplace = aliasKeys.find(key => startsWith(key, importee));
+      const toReplace = aliasKeys.find(key => matches(key, importee));
 
       if (!toReplace) {
         return null;

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,14 @@ import fs from 'fs';
 
 // Helper functions
 const noop = () => null;
-const startsWith = (needle, haystack) => ! haystack.indexOf(needle);
-const endsWith = (needle, haystack) => haystack.slice(-needle.length) === needle;
 const isFilePath = id => /^\.?\//.test(id);
+const startsWith = (needle, haystack) => {
+  if (isFilePath(haystack) || haystack.indexOf('/') !== -1) {
+    return haystack.indexOf(needle) > -1;
+  }
+  return haystack === needle;
+};
+const endsWith = (needle, haystack) => haystack.slice(-needle.length) === needle;
 const exists = uri => {
   try {
     return fs.statSync(uri).isFile();

--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,13 @@ import fs from 'fs';
 const noop = () => null;
 const isFilePath = id => /^\.?\//.test(id);
 const startsWith = (needle, haystack) => {
-  if (isFilePath(haystack) || haystack.indexOf('/') !== -1) {
-    return haystack.indexOf(needle) > -1;
+  if (needle === haystack) {
+    return true;
   }
-  return haystack === needle;
+  if (isFilePath(haystack)) {
+    return haystack.replace('./', '').indexOf(needle) === 0;
+  }
+  return haystack.split('/')[0] === needle;
 };
 const endsWith = (needle, haystack) => haystack.slice(-needle.length) === needle;
 const exists = uri => {

--- a/test/index.js
+++ b/test/index.js
@@ -19,8 +19,7 @@ test(t => {
   t.is(typeof result.resolveId, 'function');
 });
 
-// Simple aliasing
-test(t => {
+test('Simple aliasing', t => {
   const result = alias({
     foo: 'bar',
     pony: 'paradise',
@@ -36,21 +35,22 @@ test(t => {
   t.is(resolved3, 'global');
 });
 
-// Will not confuse modules with similar names
-test(t => {
+test('Will not confuse modules with similar names', t => {
   const result = alias({
     foo: 'bar',
+    './foo': 'bar',
   });
 
   const resolved = result.resolveId('foo2', '/src/importer.js');
-  const resolved2 = result.resolveId('./someFile.foo', '/src/importer.js');
+  const resolved2 = result.resolveId('./fooze/bar', '/src/importer.js');
+  const resolved3 = result.resolveId('./someFile.foo', '/src/importer.js');
 
   t.is(resolved, null);
   t.is(resolved2, null);
+  t.is(resolved3, null);
 });
 
-// Local aliasing
-test(t => {
+test('Local aliasing', t => {
   const result = alias({
     foo: './bar',
     pony: './par/a/di/se',
@@ -67,8 +67,7 @@ test(t => {
   t.is(resolved4, '/src/highly/nested/par/a/di/se.js');
 });
 
-// Absolute local aliasing
-test(t => {
+test('Absolute local aliasing', t => {
   const result = alias({
     foo: '/bar',
     pony: '/par/a/di/se.js',
@@ -85,8 +84,7 @@ test(t => {
   t.is(resolved4, '/par/a/di/se.js');
 });
 
-// Test for the resolve property
-test(t => {
+test('Test for the resolve property', t => {
   const result = alias({
     ember: './folder/hipster',
     resolve: ['.js', '.jsx'],

--- a/test/index.js
+++ b/test/index.js
@@ -24,13 +24,16 @@ test(t => {
   const result = alias({
     foo: 'bar',
     pony: 'paradise',
+    './local': 'global',
   });
 
   const resolved = result.resolveId('foo', '/src/importer.js');
   const resolved2 = result.resolveId('pony', '/src/importer.js');
+  const resolved3 = result.resolveId('./local', '/src/importer.js');
 
   t.is(resolved, 'bar');
   t.is(resolved2, 'paradise');
+  t.is(resolved3, 'global');
 });
 
 // Will not confuse modules with similar names
@@ -40,8 +43,10 @@ test(t => {
   });
 
   const resolved = result.resolveId('foo2', '/src/importer.js');
+  const resolved2 = result.resolveId('./someFile.foo', '/src/importer.js');
 
   t.is(resolved, null);
+  t.is(resolved2, null);
 });
 
 // Local aliasing

--- a/test/index.js
+++ b/test/index.js
@@ -33,6 +33,17 @@ test(t => {
   t.is(resolved2, 'paradise');
 });
 
+// Will not confuse modules with similar names
+test(t => {
+  const result = alias({
+    foo: 'bar',
+  });
+
+  const resolved = result.resolveId('foo2', '/src/importer.js');
+
+  t.is(resolved, null);
+});
+
 // Local aliasing
 test(t => {
   const result = alias({


### PR DESCRIPTION
This fixes bug I stumbled upon:

I have alias config:

``` js
alias({
  vue: 'node_modules/vue/dist/vue.js',
})
```

And want to do:

``` js
import Vue from 'vue';
import Vuex from 'vuex';
```

Currently it leads to error:

```
Error: Could not load node_modules/vue/dist/vue.jsx (imported by 
/Users/jakubszwacz/picker/app/vuex/store.js): ENOENT: no such 
file or directory, open 'node_modules/vue/dist/vue.jsx'
```
