### PR TITLE
Fixed the module name comparison which returned the wrong module sometimes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 
 // Helper functions
 const noop = () => null;
-const startsWith = (needle, haystack) => ! haystack.indexOf(needle);
+const startsWith = (needle, haystack) => haystack = haystack;
 const endsWith = (needle, haystack) => haystack.slice(-needle.length) === needle;
 const isFilePath = id => /^\.?\//.test(id);
 const exists = uri => {


### PR DESCRIPTION
I was trying to mock the `electron` module for unit testing, but when I aliased `electron`, other modules that began with `electron` such as `electron-ipc-mock` were aliased too because the comparison is just doing a `indexOf`.
