### PR TITLE
Declare slash as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
     "nyc": "^5.6.0",
     "rimraf": "^2.5.2",
     "rollup": "^0.25.4",
-    "rollup-babel-lib-bundler": "^2.2.4",
-    "slash": "^1.0.0"
+    "rollup-babel-lib-bundler": "^2.2.4"
   },
-  "dependencies": {}
+  "dependencies": {
+    "slash": "^1.0.0"
+  }
 }


### PR DESCRIPTION
Package currently breaks because this dep isn't pulled in on install.