### PR TITLE
fixed bug with resolve and absolute aliases on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,7 @@
     "rollup-babel-lib-bundler": "^2.2.4",
     "slash": "^1.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "slash": "^1.0.0"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export default function alias(options = {}) {
 
       const entry = options[toReplace];
 
-      const updatedId = importeeId.replace(toReplace, entry);
+      const updatedId = normalizeId(importeeId.replace(toReplace, entry));
 
       if (isFilePath(updatedId)) {
         const directory = path.dirname(importerId);


### PR DESCRIPTION
this pull request is to fix the bug that arises when you use absolute paths in aliases on *Windows*

for example, if you do this
```javascript
alias({
  resolve: ['.jsx', '.js'],
  lib: path.resolve(__dirname, './lib/')
})
```

and then if you import `lib/some/file` it wont resolve to `/absolute/path/project/lib/some/file.jsx`, since the `lib` alias has the drive letter in it, and the code [here](https://github.com/rollup/rollup-plugin-alias/blob/v1.3.0/src/index.js#L24) dose not test for a drive letters

to fix this, i made it strip out the drive letter once it has replaced the alias in the `importeeId` path