### PR TITLE
fix: support windows 10 system #11

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,9 +63,9 @@ export default function alias(options = {}) {
         return null;
       }
 
-      const entry = options[toReplace];
+      const entryId = normalizeId(options[toReplace]);
 
-      const updatedId = importeeId.replace(toReplace, entry);
+      const updatedId = importeeId.replace(toReplace, entryId);
 
       if (isFilePath(updatedId)) {
         const directory = path.dirname(importerId);


### PR DESCRIPTION
 `entry` must `normalizeId` before`importeeId.replace`, just like `importeeId`
Or, isFilePath(updatedId) will return `flase`
Then, will expose an error:
Could not load E:\github\vue\src\core/index

Closes #11 