### PR TITLE
Fix aliasing with path.resolve() issue on windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import platformPath, { posix as path } from 'path';
+import path, { posix } from 'path';
 import { platform } from 'os';
 import fs from 'fs';
 
@@ -68,10 +68,10 @@ export default function alias(options = {}) {
       let updatedId = normalizeId(importeeId.replace(toReplace, entry));
 
       if (isFilePath(updatedId)) {
-        const directory = path.dirname(importerId);
+        const directory = posix.dirname(importerId);
 
         // Resolve file names
-        const filePath = path.resolve(directory, updatedId);
+        const filePath = posix.resolve(directory, updatedId);
         const match = resolve.map(ext => (endsWith(ext, filePath) ? filePath : `${filePath}${ext}`))
                             .find(exists);
 
@@ -86,11 +86,11 @@ export default function alias(options = {}) {
         }
       }
 
-      // if alias is windows absoulate path return platform
-      // resolved path or rollup on windows will throw:
+      // if alias is windows absoulate path return resolved path or
+      // rollup on windows will throw:
       //  [TypeError: Cannot read property 'specifier' of undefined]
       if (VOLUME.test(entry)) {
-        return platformPath.resolve(updatedId);
+        return path.resolve(updatedId);
       }
 
       return updatedId;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { posix as path } from 'path';
+import platformPath, { posix as path } from 'path';
 import { platform } from 'os';
 import fs from 'fs';
 
@@ -31,7 +31,7 @@ const exists = uri => {
 };
 
 const normalizeId = id => {
-  if (IS_WINDOWS && typeof id === 'string') {
+  if ((IS_WINDOWS && typeof id === 'string') || VOLUME.test(id)) {
     return slash(id.replace(VOLUME, ''));
   }
 
@@ -65,27 +65,32 @@ export default function alias(options = {}) {
 
       const entry = options[toReplace];
 
-      const updatedId = importeeId.replace(toReplace, entry);
+      let updatedId = normalizeId(importeeId.replace(toReplace, entry));
 
       if (isFilePath(updatedId)) {
         const directory = path.dirname(importerId);
 
         // Resolve file names
         const filePath = path.resolve(directory, updatedId);
-        const match = resolve.map(ext => `${filePath}${ext}`)
+        const match = resolve.map(ext => (endsWith(ext, filePath) ? filePath : `${filePath}${ext}`))
                             .find(exists);
 
         if (match) {
-          return match;
-        }
-
+          updatedId = match;
         // To keep the previous behaviour we simply return the file path
         // with extension
-        if (endsWith('.js', filePath)) {
-          return filePath;
+        } else if (endsWith('.js', filePath)) {
+          updatedId = filePath;
+        } else {
+          updatedId = filePath + '.js';
         }
+      }
 
-        return filePath + '.js';
+      // if alias is windows absoulate path return platform
+      // resolved path or rollup on windows will throw:
+      //  [TypeError: Cannot read property 'specifier' of undefined]
+      if (VOLUME.test(entry)) {
+        return platformPath.resolve(updatedId);
       }
 
       return updatedId;

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,11 @@
 import test from 'ava';
-import { posix as path } from 'path';
+import paltformPath, { posix as path } from 'path';
 import { rollup } from 'rollup';
 import alias from '../dist/rollup-plugin-alias';
 import slash from 'slash';
 
-const DIRNAME = slash(__dirname.replace(/^([A-Z]:)/, ''));
+const normalizePath = (pathToNormalize) => slash(pathToNormalize.replace(/^([A-Z]:)/, ''));
+const DIRNAME = normalizePath(__dirname);
 
 test(t => {
   t.is(typeof alias, 'function');
@@ -116,6 +117,43 @@ test(t => {
   const resolved = result.resolveId('resolve', path.resolve(DIRNAME, './files/index.js'));
 
   t.is(resolved, path.resolve(DIRNAME, './files/i/am/a/local/file.js'));
+});
+
+// this test with old behaviour will fail on windows and pass on Uinx-Like platforms
+test('Platform path.resolve(\'file-without-extension\') aliasing', t => {
+  // this what used in React and Vue
+  const result = alias({
+    test: paltformPath.resolve('./files/aliasMe'),
+  });
+
+  const resolved = result.resolveId('test', path.resolve(DIRNAME, './files/index.js'));
+
+  t.is(resolved, paltformPath.resolve('./files/aliasMe.js'));
+});
+
+// this test with old behaviour will fail on windows and Uinx-Like platforms
+test('Windows absolute path aliasing', t => {
+  const result = alias({
+    resolve: 'E:\\react\\node_modules\\fbjs\\lib\\warning',
+  });
+
+  const resolved = result.resolveId('resolve', path.resolve(DIRNAME, './files/index.js'));
+
+  t.is(
+    normalizePath(resolved),
+    normalizePath('E:\\react\\node_modules\\fbjs\\lib\\warning.js')
+  );
+});
+
+test('Platform path.resolve(\'file-with.ext\') aliasing', t => {
+  const result = alias({
+    test: paltformPath.resolve('./files/folder/hipster.jsx'),
+    resolve: ['.js', '.jsx'],
+  });
+
+  const resolved = result.resolveId('test', path.resolve(DIRNAME, './files/index.js'));
+
+  t.is(resolved, paltformPath.resolve('./files/folder/hipster.jsx'));
 });
 
 // Tests in Rollup

--- a/test/index.js
+++ b/test/index.js
@@ -144,7 +144,7 @@ test('Windows absolute path aliasing', t => {
     normalizePath('E:\\react\\node_modules\\fbjs\\lib\\warning.js')
   );
 });
-
+// test alaising with resolved paths
 test('Platform path.resolve(\'file-with.ext\') aliasing', t => {
   const result = alias({
     test: path.resolve('./files/folder/hipster.jsx'),

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import paltformPath, { posix as path } from 'path';
+import path, { posix } from 'path';
 import { rollup } from 'rollup';
 import alias from '../dist/rollup-plugin-alias';
 import slash from 'slash';
@@ -94,9 +94,9 @@ test('Test for the resolve property', t => {
     resolve: ['.js', '.jsx'],
   });
 
-  const resolved = result.resolveId('ember', path.resolve(DIRNAME, './files/index.js'));
+  const resolved = result.resolveId('ember', posix.resolve(DIRNAME, './files/index.js'));
 
-  t.is(resolved, path.resolve(DIRNAME, './files/folder/hipster.jsx'));
+  t.is(resolved, posix.resolve(DIRNAME, './files/folder/hipster.jsx'));
 });
 
 test(t => {
@@ -114,21 +114,21 @@ test(t => {
     resolve: './i/am/a/local/file',
   });
 
-  const resolved = result.resolveId('resolve', path.resolve(DIRNAME, './files/index.js'));
+  const resolved = result.resolveId('resolve', posix.resolve(DIRNAME, './files/index.js'));
 
-  t.is(resolved, path.resolve(DIRNAME, './files/i/am/a/local/file.js'));
+  t.is(resolved, posix.resolve(DIRNAME, './files/i/am/a/local/file.js'));
 });
 
 // this test with old behaviour will fail on windows and pass on Uinx-Like platforms
 test('Platform path.resolve(\'file-without-extension\') aliasing', t => {
   // this what used in React and Vue
   const result = alias({
-    test: paltformPath.resolve('./files/aliasMe'),
+    test: path.resolve('./files/aliasMe'),
   });
 
-  const resolved = result.resolveId('test', path.resolve(DIRNAME, './files/index.js'));
+  const resolved = result.resolveId('test', posix.resolve(DIRNAME, './files/index.js'));
 
-  t.is(resolved, paltformPath.resolve('./files/aliasMe.js'));
+  t.is(resolved, path.resolve('./files/aliasMe.js'));
 });
 
 // this test with old behaviour will fail on windows and Uinx-Like platforms
@@ -137,7 +137,7 @@ test('Windows absolute path aliasing', t => {
     resolve: 'E:\\react\\node_modules\\fbjs\\lib\\warning',
   });
 
-  const resolved = result.resolveId('resolve', path.resolve(DIRNAME, './files/index.js'));
+  const resolved = result.resolveId('resolve', posix.resolve(DIRNAME, './files/index.js'));
 
   t.is(
     normalizePath(resolved),
@@ -147,13 +147,13 @@ test('Windows absolute path aliasing', t => {
 
 test('Platform path.resolve(\'file-with.ext\') aliasing', t => {
   const result = alias({
-    test: paltformPath.resolve('./files/folder/hipster.jsx'),
+    test: path.resolve('./files/folder/hipster.jsx'),
     resolve: ['.js', '.jsx'],
   });
 
-  const resolved = result.resolveId('test', path.resolve(DIRNAME, './files/index.js'));
+  const resolved = result.resolveId('test', posix.resolve(DIRNAME, './files/index.js'));
 
-  t.is(resolved, paltformPath.resolve('./files/folder/hipster.jsx'));
+  t.is(resolved, path.resolve('./files/folder/hipster.jsx'));
 });
 
 // Tests in Rollup


### PR DESCRIPTION
@Rich-Harris Could you take a look?

### Added 3 test  cases:
- Platform path.resolve('file-without-extension') aliasing
- Windows absolute path aliasing
- Platform path.resolve('file-with.ext') aliasing 

### This fix:
- facebook/react#9350
- facebook/react#9540 [only the part that related to rollup-plugin-alias]
- vuejs/vue#4338

### And Closes #11