### PR TITLE
feat: resolve ids for directories with an index.js module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,8 +72,10 @@ export default function alias(options = {}) {
 
         // Resolve file names
         const filePath = path.resolve(directory, updatedId);
-        const match = resolve.map(ext => `${filePath}${ext}`)
-                            .find(exists);
+        const match = resolve
+          .map(ext => [`${filePath}${ext}`, `${filePath}/index${ext}`])
+          .reduce((variants, variant) => variants.concat(variant), [])
+          .find(exists);
 
         if (match) {
           return match;

--- a/test/index.js
+++ b/test/index.js
@@ -137,3 +137,13 @@ test(t =>
     t.is(stats.modules.length, 5);
   })
 );
+
+test('Resolving directories via index.js', t => {
+  const result = alias({
+    folder: './folder',
+  });
+
+  const resolved = result.resolveId('folder', path.resolve(DIRNAME, './files/aliasMe.js'));
+
+  t.is(resolved, path.resolve(DIRNAME, './files/folder/index.js'));
+});


### PR DESCRIPTION
Adds the ability to resolve the following from `key: './path/to/value'`:

- `'path/to/value.js'`
- `'path/to/value/index.js'`

This still needs tests. Just submitting a PR so I don't forget!
