### PR TITLE
Use "module" in addition to "jsnext:main"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.1",
   "description": "Resolves aliases with Rollup",
   "main": "dist/rollup-plugin-alias.js",
+  "module": "dist/rollup-plugin-alias.es2015.js",
   "jsnext:main": "dist/rollup-plugin-alias.es2015.js",
   "scripts": {
     "prebuild": "rimraf dist",


### PR DESCRIPTION
This change (probably) fixes my cryptic error

```
Error: 'default' is not exported by node_modules\rollup-plugin-alias\dist\rollup-plugin-alias.js
```

which I assume means it is loading `rollup-plugin-alias\dist\rollup-plugin-alias.js` instead of `rollup-plugin-alias\dist\rollup-plugin-alias.es2015.js`, which I assume is because `rollup-plugin-node-resolve` uses the default options `module: true, main: true, jsnext: false`.

I think this PR is very minimal and will not have any adverse effects or break compatibility, but you never know.