### PR TITLE
Fix aliasing that matches entry file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ export default function alias(options = {}) {
       // First match is supposed to be the correct one
       const toReplace = aliasKeys.find(key => matches(key, importeeId));
 
-      if (!toReplace) {
+      if (!toReplace || !importerId) {
         return null;
       }
 

--- a/test/index.js
+++ b/test/index.js
@@ -87,6 +87,16 @@ test('Absolute local aliasing', t => {
   t.is(resolved4, '/par/a/di/se.js');
 });
 
+test('Leaves entry file untouched if matches alias', t => {
+  const result = alias({
+    abacaxi: './abacaxi',
+  });
+
+  const resolved = result.resolveId('abacaxi/entry.js', undefined);
+
+  t.is(resolved, null);
+});
+
 test('Test for the resolve property', t => {
   const result = alias({
     ember: './folder/hipster',


### PR DESCRIPTION
When the alias matches the entry file, there is no `importerId` given, which fails with:

```
Path must be a string. Received undefined
```

This PR checks that `importerId` exists before trying to force an alias.