### PR TITLE
fix-bug: Could not load G:\luobata\canvas-input-methods\src\ui/index (imported.....

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const matches = (key, importee) => {
   return importeeStartsWithKey && importeeHasSlashAfterKey;
 };
 const endsWith = (needle, haystack) => haystack.slice(-needle.length) === needle;
-const isFilePath = id => /^\.?\//.test(id);
+const isFilePath = id => /^(\.|\w:|)?\//.test(id);
 const exists = uri => {
   try {
     return fs.statSync(uri).isFile();
@@ -65,7 +65,7 @@ export default function alias(options = {}) {
 
       const entry = options[toReplace];
 
-      const updatedId = importeeId.replace(toReplace, entry);
+      const updatedId = importeeId.replace(toReplace, entry).split(path.sep).join('/');
 
       if (isFilePath(updatedId)) {
         const directory = path.dirname(importerId);


### PR DESCRIPTION
I find it will throw out an exception when I import a module with alias like 'import init from 'UI/index.js' in window. It's same as the issue #11 .

And I find it it's the bug with the updatedId in windows in started with 'G:\' so it can't be match by the regex /^\.?\//, so I change the regex and format the updatedId(.split(path.sep).join('/')) to promise it would be matched by the regex.

I also find it that the dist file in the node_modules in version 1.3.1, it has posix.resolve, and path.resolve in source code.And I had tested that it work with path.resolve after my PR.

Signed-off-by: Luobata <602975805@qq.com>