### PR TITLE
fix lower case volumes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import fs from 'fs';
 
 import slash from 'slash';
 
-const VOLUME = /^([A-Z]:)/;
+const VOLUME = /^([A-Za-z]:)/;
 const IS_WINDOWS = platform() === 'win32';
 
 // Helper functions


### PR DESCRIPTION
When the volume is in lower-case, the plugin generate bad ids.
For example x:/module.js instead of x:\module.js

