### PR TITLE
Add RegExp support and strict order of entries (+unit-tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ export default {
       entries:[
         {find:'somelibrary', replacement: './mylocallibrary'},
         {find:/^foobar\/path.*/i, replacement: './bar'},
-        {find:/^test\/(.*)/i, replacement: './anotherfolder/$1'
+        {find:/^test\/(.*)/i, replacement: './anotherfolder/$1'},
+        {find:/^test$/i, replacement: 'super-secret-sausage-library'}
       ]
     })
   ],

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ export default {
       resolve: ['.jsx', '.js'], //optional, by default this will just look for .js files or folders
       entries:[
         {find:'somelibrary', replacement: './mylocallibrary'},
-        {find:/^.\/foobar\/path.*/i, replacement: './bar'},
-        {find:/^.\/test\/(.*)/i, replacement: './anotherfolder/$1'
+        {find:/^foobar\/path.*/i, replacement: './bar'},
+        {find:/^test\/(.*)/i, replacement: './anotherfolder/$1'
       ]
     })
   ],

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ export default {
     resolve: ['.jsx', '.js'],
     entries:[
       {find:'somelibrary', replacement: './mylocallibrary'},
-      {find:/^./foobar\/path.*/i, replacement: './bar'},
-      {find:/^./test/(.*)/i, replacement: './anotherfolder/$1'
+      {find:/^.\/foobar\/path.*/i, replacement: './bar'},
+      {find:/^.\/test\/(.*)/i, replacement: './anotherfolder/$1'
     ]
   })],
 };

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ export default {
     alias({
       resolve: ['.jsx', '.js'], //optional, by default this will just look for .js files or folders
       entries:[
-        {find:'something", replacement: '../../../something'}, //the initial example
+        {find:'something', replacement: '../../../something'}, //the initial example
         {find:'somelibrary-1.0.0', replacement: './mylocallibrary-1.5.0'}, //remap a library with a specific version
         {find:/^i18n\!(.*)/, replacement: '$1'}, //remove something in front of the import (e.g. loaders, that were previously transpiled via the AMD module)
         //for whatever reason, replace all .js extensions with .wasm

--- a/README.md
+++ b/README.md
@@ -35,14 +35,16 @@ import alias from 'rollup-plugin-alias';
 
 export default {
   input: './src/index.js',
-  plugins: [alias({
-    resolve: ['.jsx', '.js'], //optional, by default this will just look for .js files or folders
-    entries:[
-      {find:'somelibrary', replacement: './mylocallibrary'},
-      {find:/^.\/foobar\/path.*/i, replacement: './bar'},
-      {find:/^.\/test\/(.*)/i, replacement: './anotherfolder/$1'
-    ]
-  })],
+  plugins: [
+    alias({
+      resolve: ['.jsx', '.js'], //optional, by default this will just look for .js files or folders
+      entries:[
+        {find:'somelibrary', replacement: './mylocallibrary'},
+        {find:/^.\/foobar\/path.*/i, replacement: './bar'},
+        {find:/^.\/test\/(.*)/i, replacement: './anotherfolder/$1'
+      ]
+    })
+  ],
 };
 ```
 The order of the entries is important, in that the first rules are applied first.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import alias from 'rollup-plugin-alias';
 export default {
   input: './src/index.js',
   plugins: [alias({
-    resolve: ['.jsx', '.js'],
+    resolve: ['.jsx', '.js'], //optional, by default this will just look for .js files or folders
     entries:[
       {find:'somelibrary', replacement: './mylocallibrary'},
       {find:/^.\/foobar\/path.*/i, replacement: './bar'},
@@ -47,26 +47,7 @@ export default {
 ```
 The order of the entries is important, in that the first rules are applied first.
 
-You can now also include Regular Expressions to search in a way more distinct and complex manner.
-
-An optional `resolve` array with file extensions can be provided.
-If present local aliases beginning with `./` will be resolved to existing files:
-
-```javascript
-// rollup.config.js
-import alias from 'rollup-plugin-alias';
-
-export default {
-  input: './src/index.js',
-  plugins: [alias({
-    resolve: ['.jsx', '.js'], //optional, by default this will just look for .js files
-    entries:[
-      {find:'foo', replacement: './bar'}  // Will check for ./bar.jsx and ./bar.js
-    ]
-  })],
-};
-```
-If not given local aliases will be resolved with a `.js` extension.
+You use Regular Expressions to search in a way more distinct and complex manner.
 
 ## License
 MIT, see `LICENSE` for more information

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export default {
 ```
 The order of the entries is important, in that the first rules are applied first.
 
-You use Regular Expressions to search in a way more distinct and complex manner.
+You can use either simple Strings or Regular Expressions to search in a more distinct and complex manner (e.g. to do partial replacements via subpattern-matching, see aboves example).
 
 ## License
 MIT, see `LICENSE` for more information

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ import alias from 'rollup-plugin-alias';
 export default {
   input: './src/index.js',
   plugins: [alias({
-    resolve: ['.jsx', '.js'],
+    resolve: ['.jsx', '.js'], //optional, by default this will just look for .js files
     entries:[
       {find:'foo', replacement: './bar'}  // Will check for ./bar.jsx and ./bar.js
     ]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ export default {
       entries:[
         {find:'something', replacement: '../../../something'}, //the initial example
         {find:'somelibrary-1.0.0', replacement: './mylocallibrary-1.5.0'}, //remap a library with a specific version
-        {find:/^i18n\!(.*)/, replacement: '$1'}, //remove something in front of the import (e.g. loaders, that were previously transpiled via the AMD module)
+        {find:/^i18n\!(.*)/, replacement: '$1.js'}, //remove something in front of the import and append an extension (e.g. loaders, for files that were previously transpiled via the AMD module, to properly handle them in rollup as internals now)
         //for whatever reason, replace all .js extensions with .wasm
         {find:/^(.*)\.js$/, replacement: '$1.wasm'} 
       ]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For Webpack users: This is a plugin to mimic the `resolve.alias` functionality i
 ```
 $ npm install rollup-plugin-alias
 ```
-
+#
 ## Usage
 ```javascript
 // rollup.config.js
@@ -39,12 +39,12 @@ export default {
     resolve: ['.jsx', '.js'],
     entries:[
       {find:'somelibrary', replacement: './mylocallibrary'},
-      {find:^./foobar\/path.*/i, replacement: './bar', isRegEx:true} 
+      {find:/^./foobar\/path.*/i, replacement: './bar', isRegEx:true} 
     ]
   })],
 };
 ```
-The order of the entries are important, in that are the first rules are applied first (obviously). :) 
+The order of the entries is important, in that the first rules are applied first.
 
 You can now also include Regular Expressions to search in a way more distinct and complex manner:
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ export default {
   })],
 };
 ```
+The order of the entries are important, in that are the first rules are applied first (obviously). :) 
+
+You can now also include Regular Expressions to search in a way more distinct and complex manner:
+
+An optional `resolve` array with file extensions can be provided.
+If present local aliases beginning with `./` will be resolved to existing files:
+
+```javascript
+// rollup.config.js
+import alias from 'rollup-plugin-alias';
+
+export default {
+  input: './src/index.js',
+  plugins: [alias({
+    resolve: ['.jsx', '.js'],
+    entries:[
+      {find:^./foobar\/path.*/i, replacement: './bar'} 
+    ]
+  })],
+};
+```
 
 An optional `resolve` array with file extensions can be provided.
 If present local aliases beginning with `./` will be resolved to existing files:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ import alias from 'rollup-plugin-alias';
 export default {
   input: './src/index.js',
   plugins: [alias({
-    somelibrary: './mylocallibrary'
+    entries:[
+      {find:'somelibrary', replacement: './mylocallibrary'}
+    ]
   })],
 };
 ```
@@ -52,7 +54,9 @@ export default {
   input: './src/index.js',
   plugins: [alias({
     resolve: ['.jsx', '.js'],
-    foo: './bar'  // Will check for ./bar.jsx and ./bar.js
+    entries:[
+      {find:'foo', replacement: './bar'}  // Will check for ./bar.jsx and ./bar.js
+    ]
   })],
 };
 ```

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ import alias from 'rollup-plugin-alias';
 export default {
   input: './src/index.js',
   plugins: [alias({
+    resolve: ['.jsx', '.js'],
     entries:[
-      {find:'somelibrary', replacement: './mylocallibrary'}
+      {find:'somelibrary', replacement: './mylocallibrary'},
+      {find:^./foobar\/path.*/i, replacement: './bar', isRegEx:true} 
     ]
   })],
 };
@@ -45,24 +47,6 @@ export default {
 The order of the entries are important, in that are the first rules are applied first (obviously). :) 
 
 You can now also include Regular Expressions to search in a way more distinct and complex manner:
-
-An optional `resolve` array with file extensions can be provided.
-If present local aliases beginning with `./` will be resolved to existing files:
-
-```javascript
-// rollup.config.js
-import alias from 'rollup-plugin-alias';
-
-export default {
-  input: './src/index.js',
-  plugins: [alias({
-    resolve: ['.jsx', '.js'],
-    entries:[
-      {find:^./foobar\/path.*/i, replacement: './bar'} 
-    ]
-  })],
-};
-```
 
 An optional `resolve` array with file extensions can be provided.
 If present local aliases beginning with `./` will be resolved to existing files:

--- a/README.md
+++ b/README.md
@@ -39,14 +39,15 @@ export default {
     resolve: ['.jsx', '.js'],
     entries:[
       {find:'somelibrary', replacement: './mylocallibrary'},
-      {find:/^./foobar\/path.*/i, replacement: './bar', isRegEx:true} 
+      {find:/^./foobar\/path.*/i, replacement: './bar'},
+      {find:/^./test/(.*)/i, replacement: './anotherfolder/$1'
     ]
   })],
 };
 ```
 The order of the entries is important, in that the first rules are applied first.
 
-You can now also include Regular Expressions to search in a way more distinct and complex manner:
+You can now also include Regular Expressions to search in a way more distinct and complex manner.
 
 An optional `resolve` array with file extensions can be provided.
 If present local aliases beginning with `./` will be resolved to existing files:

--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ export default {
     alias({
       resolve: ['.jsx', '.js'], //optional, by default this will just look for .js files or folders
       entries:[
-        {find:'somelibrary', replacement: './mylocallibrary'},
-        {find:/^foobar\/path.*/i, replacement: './bar'},
-        {find:/^test\/(.*)/i, replacement: './anotherfolder/$1'},
-        {find:/^test$/i, replacement: 'super-secret-sausage-library'}
+        {find:'somelibrary-1.0.0', replacement: './mylocallibrary-1.5.0'}, //remap a library with a specific version
+        {find:/^i18n\!(.*)/, replacement: '$1'}, //remove some loaders (e.g. when they're transpiled via the AMD module)
+        {find:/^(.*)\.js$/, replacement: '$1.wasm'} //for whatever reason, replace all .js extensions with .wasm
       ]
     })
   ],

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ export default {
     alias({
       resolve: ['.jsx', '.js'], //optional, by default this will just look for .js files or folders
       entries:[
+        {find:'something", replacement: '../../../something'}, //the initial example
         {find:'somelibrary-1.0.0', replacement: './mylocallibrary-1.5.0'}, //remap a library with a specific version
-        {find:/^i18n\!(.*)/, replacement: '$1'}, //remove some loaders (e.g. when they're transpiled via the AMD module)
-        {find:/^(.*)\.js$/, replacement: '$1.wasm'} //for whatever reason, replace all .js extensions with .wasm
+        {find:/^i18n\!(.*)/, replacement: '$1'}, //remove something in front of the import (e.g. loaders, that were previously transpiled via the AMD module)
+        //for whatever reason, replace all .js extensions with .wasm
+        {find:/^(.*)\.js$/, replacement: '$1.wasm'} 
       ]
     })
   ],

--- a/test/index.js
+++ b/test/index.js
@@ -44,19 +44,19 @@ test('Simple aliasing', (t) => {
 test('RegExp aliasing', (t) => {
   const result = alias({
     entries: [
-      {find:new RegExp('fo.*'), replacement:'foobar2019', isRegEx:true},
-      {find:new RegExp('.*pony.*'), replacement:'i/am/a/barbie/girl', isRegEx:true},
-      {find:new RegExp('^test/$'), replacement:'this/is/strict', isRegEx:true}
+      {find:/f(o+)bar/, replacement:'f$1bar2019'},
+      {find:new RegExp('.*pony.*'), replacement:'i/am/a/barbie/girl'},
+      {find:/^test\/$/, replacement:'this/is/strict'}
     ]
   });
 
-  const resolved = result.resolveId('foobar', '/src/importer.js');
+  const resolved = result.resolveId('fooooooooobar', '/src/importer.js');
   const resolved2 = result.resolveId('im/a/little/pony/yes', '/src/importer.js');
   const resolved3 = result.resolveId('./test', '/src/importer.js');
   const resolved4 = result.resolveId('test', '/src/importer.js');
   const resolved5 = result.resolveId('test/', '/src/importer.js');
 
-  t.is(resolved, 'foobar2019');
+  t.is(resolved, 'fooooooooobar2019');
   t.is(resolved2, 'i/am/a/barbie/girl');
   t.is(resolved3, null);
   t.is(resolved4, null);

--- a/test/index.js
+++ b/test/index.js
@@ -25,9 +25,11 @@ test('defaults', (t) => {
 
 test('Simple aliasing', (t) => {
   const result = alias({
-    foo: 'bar',
-    pony: 'paradise',
-    './local': 'global',
+    entries: [
+      {find:'foo', replacement:'bar'},
+      {find:'pony', replacement:'paradise'},
+      {find:'./local',replacement:'global'}
+    ]
   });
 
   const resolved = result.resolveId('foo', '/src/importer.js');
@@ -39,10 +41,34 @@ test('Simple aliasing', (t) => {
   t.is(resolved3, 'global');
 });
 
+test('RegExp aliasing', (t) => {
+  const result = alias({
+    entries: [
+      {find:new RegExp('fo.*'), replacement:'foobar2019', isRegEx:true},
+      {find:new RegExp('.*pony.*'), replacement:'i/am/a/barbie/girl', isRegEx:true},
+      {find:new RegExp('^test/$'), replacement:'this/is/strict', isRegEx:true}
+    ]
+  });
+
+  const resolved = result.resolveId('foobar', '/src/importer.js');
+  const resolved2 = result.resolveId('im/a/little/pony/yes', '/src/importer.js');
+  const resolved3 = result.resolveId('./test', '/src/importer.js');
+  const resolved4 = result.resolveId('test', '/src/importer.js');
+  const resolved5 = result.resolveId('test/', '/src/importer.js');
+
+  t.is(resolved, 'foobar2019');
+  t.is(resolved2, 'i/am/a/barbie/girl');
+  t.is(resolved3, null);
+  t.is(resolved4, null);
+  t.is(resolved5, 'this/is/strict');
+});
+
 test('Will not confuse modules with similar names', (t) => {
   const result = alias({
-    foo: 'bar',
-    './foo': 'bar',
+    entries:[
+      {find:'foo', replacement:'bar'},
+      {find:'./foo', replacement:'bar'},
+    ]
   });
 
   const resolved = result.resolveId('foo2', '/src/importer.js');
@@ -56,8 +82,10 @@ test('Will not confuse modules with similar names', (t) => {
 
 test('Local aliasing', (t) => {
   const result = alias({
-    foo: './bar',
-    pony: './par/a/di/se',
+    entries:[
+      {find:'foo', replacement:'./bar'},
+      {find:'pony', replacement:'./par/a/di/se'}
+    ]
   });
 
   const resolved = result.resolveId('foo', '/src/importer.js');
@@ -73,8 +101,10 @@ test('Local aliasing', (t) => {
 
 test('Absolute local aliasing', (t) => {
   const result = alias({
-    foo: '/bar',
-    pony: '/par/a/di/se.js',
+    entries:[
+      {find:'foo', replacement:'/bar'},
+      {find:'pony', replacement:'/par/a/di/se.js'}
+    ]
   });
 
   const resolved = result.resolveId('foo', '/src/importer.js');
@@ -90,7 +120,9 @@ test('Absolute local aliasing', (t) => {
 
 test('Leaves entry file untouched if matches alias', (t) => {
   const result = alias({
-    abacaxi: './abacaxi',
+    entries:[
+      {find:'abacaxi', replacement:'./abacaxi'}
+    ]
   });
 
   const resolved = result.resolveId('abacaxi/entry.js', undefined);
@@ -100,8 +132,10 @@ test('Leaves entry file untouched if matches alias', (t) => {
 
 test('Test for the resolve property', (t) => {
   const result = alias({
-    ember: './folder/hipster',
     resolve: ['.js', '.jsx'],
+    entries:[
+      {find:'ember', replacement: './folder/hipster'},
+    ]
   });
 
   const resolved = result.resolveId('ember', posix.resolve(DIRNAME, './files/index.js'));
@@ -111,7 +145,9 @@ test('Test for the resolve property', (t) => {
 
 test('i/am/a/file', (t) => {
   const result = alias({
-    resolve: 'i/am/a/file',
+    entries:[
+      {find:'resolve', replacement: 'i/am/a/file'}
+    ]
   });
 
   const resolved = result.resolveId('resolve', '/src/import.js');
@@ -121,7 +157,9 @@ test('i/am/a/file', (t) => {
 
 test('i/am/a/local/file', (t) => {
   const result = alias({
-    resolve: './i/am/a/local/file',
+    entries:[
+      {find:'resolve', replacement: './i/am/a/local/file'}
+    ]
   });
 
   const resolved = result.resolveId('resolve', posix.resolve(DIRNAME, './files/index.js'));
@@ -132,7 +170,9 @@ test('i/am/a/local/file', (t) => {
 test('Platform path.resolve(\'file-without-extension\') aliasing', (t) => {
   // this what used in React and Vue
   const result = alias({
-    test: path.resolve('./test/files/aliasMe'),
+    entries:[
+      {find:'test', replacement:path.resolve('./test/files/aliasMe')}
+    ]
   });
 
   const resolved = result.resolveId('test', posix.resolve(DIRNAME, './files/index.js'));
@@ -142,7 +182,9 @@ test('Platform path.resolve(\'file-without-extension\') aliasing', (t) => {
 
 test('Windows absolute path aliasing', (t) => {
   const result = alias({
-    resolve: 'E:\\react\\node_modules\\fbjs\\lib\\warning',
+    entries:[
+      {find:'resolve', replacement:'E:\\react\\node_modules\\fbjs\\lib\\warning'}
+    ]
   });
 
   const resolved = result.resolveId('resolve', posix.resolve(DIRNAME, './files/index.js'));
@@ -155,7 +197,9 @@ test('Windows absolute path aliasing', (t) => {
 
 test('Platform path.resolve(\'file-with.ext\') aliasing', (t) => {
   const result = alias({
-    test: path.resolve('./test/files/folder/hipster.jsx'),
+    entries:[
+      {find:'test', replacement:path.resolve('./test/files/folder/hipster.jsx')},
+    ],
     resolve: ['.js', '.jsx'],
   });
 
@@ -181,10 +225,12 @@ const getModuleIdsFromBundle = (bundle) => {
 test('Works in rollup', t => rollup({
   input: './test/files/index.js',
   plugins: [alias({
-    fancyNumber: './aliasMe',
-    './anotherFancyNumber': './localAliasMe',
-    numberFolder: './folder',
-    './numberFolder': './folder',
+    entries:[
+      {find:'fancyNumber', replacement:'./aliasMe'},
+      {find:'./anotherFancyNumber', replacement: './localAliasMe'},
+      {find:'numberFolder', replacement:'./folder'},
+      {find:'./numberFolder', replacement: './folder'}
+    ]
   })],
 }).then(getModuleIdsFromBundle)
   .then((moduleIds) => {


### PR DESCRIPTION
Added support for Regular Expressions and switched from an object to an array for the entries to keep a strict order in which rules are queried (unlike previously).

This will change the options a bit - with the added bonus of better readability (basically you'll have to specify the 'find' property instead of abusing the object-key for the search-string. 

Edit: Maybe a Set would give better performance, will have to revisit later on - for now this is sufficient to get started (at least for us)

Edit 2: Also keep in mind that this is currently not backwards compatible with the old configuration, that would need some extra work, if desired.

Edit 3: For examples see README.md in my Repo.