### PR TITLE
Add support for object syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,22 @@ export default {
         {find:'somelibrary-1.0.0', replacement: './mylocallibrary-1.5.0'}, //remap a library with a specific version
         {find:/^i18n\!(.*)/, replacement: '$1.js'}, //remove something in front of the import and append an extension (e.g. loaders, for files that were previously transpiled via the AMD module, to properly handle them in rollup as internals now)
         //for whatever reason, replace all .js extensions with .wasm
-        {find:/^(.*)\.js$/, replacement: '$1.wasm'} 
+        {find:/^(.*)\.js$/, replacement: '$1.wasm'}
       ]
+    })
+  ],
+};
+
+// or with object syntax
+export default {
+  input: './src/index.js',
+  plugins: [
+    alias({
+      resolve: ['.jsx', '.js'],
+      entries: {
+        something: '../../../something',
+        'somelibrary-1.0.0': './mylocallibrary-1.5.0',
+      }
     })
   ],
 };

--- a/src/index.js
+++ b/src/index.js
@@ -40,12 +40,24 @@ const normalizeId = (id) => {
   return id;
 };
 
+const getEntries = ({ entries }) => {
+  if (!entries) {
+    return [];
+  }
+
+  if (Array.isArray(entries)) {
+    return entries;
+  }
+
+  return Object.keys(entries).map(key => ({ find: key, replacement: entries[key] }));
+};
+
 export default function alias(options = {}) {
   const resolve = Array.isArray(options.resolve) ? options.resolve : ['.js'];
-  const entries = options.entries?options.entries:[];
+  const entries = getEntries(options);
 
   // No aliases?
-  if (!entries || entries.length === 0) {
+  if (entries.length === 0) {
     return {
       resolveId: noop,
     };

--- a/test/index.js
+++ b/test/index.js
@@ -23,13 +23,31 @@ test('defaults', (t) => {
   t.is(typeof result.resolveId, 'function');
 });
 
-test('Simple aliasing', (t) => {
+test('Simple aliasing (array)', (t) => {
   const result = alias({
     entries: [
       {find:'foo', replacement:'bar'},
       {find:'pony', replacement:'paradise'},
       {find:'./local',replacement:'global'}
     ]
+  });
+
+  const resolved = result.resolveId('foo', '/src/importer.js');
+  const resolved2 = result.resolveId('pony', '/src/importer.js');
+  const resolved3 = result.resolveId('./local', '/src/importer.js');
+
+  t.is(resolved, 'bar');
+  t.is(resolved2, 'paradise');
+  t.is(resolved3, 'global');
+});
+
+test('Simple aliasing (object)', (t) => {
+  const result = alias({
+    entries:  {
+      foo: 'bar',
+      pony: 'paradise',
+      './local': 'global'
+    }
   });
 
   const resolved = result.resolveId('foo', '/src/importer.js');


### PR DESCRIPTION
This sort of fixes https://github.com/rollup/rollup-plugin-alias/issues/58 . 

It ain't fully backward-compatible with v1 but it brings back support for "simpler" object-based syntax for aliases. Why it isn't fully compatible? Because in v1 we would pass in alias-object right into the plugin, this PR requires it to be passed as `entries` option. I believe it's better to leave it like this (without introducing full backward compatibility) because it's less confusing around using other options (than `entries`) - v1 had this quirky behavior or allowing an alias map UNLESS it had `resolve` key (then you had to nest your alias map).