### PR TITLE
Fix alias discrepancy with Webpack 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 npm-debug.log
 
+.nyc_output
 dist

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,13 @@ export default function alias(options = {}) {
         } else if (endsWith('.js', filePath)) {
           updatedId = filePath;
         } else {
-          updatedId = filePath + '.js';
+          const indexFilePath = posix.resolve(directory, `${updatedId}/index`);
+          const defaultMatch = resolve.map(ext => `${indexFilePath}${ext}`).find(exists);
+          if (defaultMatch) {
+            updatedId = defaultMatch;
+          } else {
+            updatedId = filePath + '.js';
+          }
         }
       }
 

--- a/test/index.js
+++ b/test/index.js
@@ -180,6 +180,20 @@ test('Platform path.resolve(\'file-without-extension\') aliasing', (t) => {
   t.is(resolved, path.resolve('./test/files/aliasMe.js'));
 });
 
+test('Platform path.resolve(\'just-a-folder\') aliasing', (t) => {
+  // this what used in RSvelte
+  const result = alias({
+    resolve: ['.svelte', '.js'],
+    entries:[
+      {find:'test', replacement:path.resolve('./test/files/Svelte')}
+    ]
+  });
+
+  const resolved = result.resolveId('test', posix.resolve(DIRNAME, './files/index.js'));
+
+  t.is(resolved, path.resolve('./test/files/Svelte/index.svelte'));
+});
+
 test('Windows absolute path aliasing', (t) => {
   const result = alias({
     entries:[


### PR DESCRIPTION
Fixing the discrepancy of alias functionality of adding `index.{ext}` if the alias is a folder as mentioned in the issue #63 